### PR TITLE
`render_string` return rendered template string, not set to `this.body`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jade.locals.someKey = 'some value'
 
 app.use(function* () {
   this.render('index', locals_for_this_page, true)
-  // this.body = this.render_string('index', locals_for_this_page, true)
+  // this.body = this.renderString('index', locals_for_this_page, true)
 })
 ```
 
@@ -190,14 +190,14 @@ If `options` is set to `true` or `false`, it will be treated as `noCache`, and `
 
 `options` and `noCache` are optional.
 
-### ctx.render_string()
+### ctx.renderString()
 
-different from `ctx.render`, `ctx.render_string` return rendered template string do not set to `this.body`.
+different from `ctx.render`, `ctx.renderString` return rendered template string do not set to `this.body`.
 
 ```js
 app.use(function* () {
   this.body = {
-    html: this.render_string('index', locals_for_this_page, true)
+    html: this.renderString('index', locals_for_this_page, true)
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jade.locals.someKey = 'some value'
 
 app.use(function* () {
   this.render('index', locals_for_this_page, true)
+  // this.body = this.render_string('index', locals_for_this_page, true)
 })
 ```
 
@@ -188,6 +189,18 @@ Render template, and set rendered template to `this.body`.
 If `options` is set to `true` or `false`, it will be treated as `noCache`, and `noCache` will be ignored. For example, `render(tpl, locals, true)` equals to `render(tpl, locals, {}, true)`, and `render(tpl, locals, true, false)` will skip cache and re-compile template.
 
 `options` and `noCache` are optional.
+
+### ctx.render_string()
+
+different from `ctx.render`, `ctx.render_string` return rendered template string do not set to `this.body`.
+
+```js
+app.use(function* () {
+  this.body = {
+    html: this.render_string('index', locals_for_this_page, true)
+  }
+})
+```
 
 ## basedir
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function Jade (options) {
    * Render template, and set rendered template to `this.body`
    */
   function renderer () {
-    this.body = render_string.apply(this, arguments)
+    this.body = renderString.apply(this, arguments)
     this.type = 'text/html'
     return this
   }
@@ -120,7 +120,7 @@ function Jade (options) {
    * @param {Object}  options options that pass to Jade compiler, merged with global default options
    * @param {Boolean} noCache use cache or not
    */
-  function render_string (tpl, locals, options, noCache) {
+  function renderString (tpl, locals, options, noCache) {
     var compileOptions = _.merge({}, defaultOptions)
     var skipCache
 
@@ -148,7 +148,7 @@ function Jade (options) {
       enumerable: true,
       value: function (app) {
         app.context.render = renderer
-        app.context.render_string = render_string
+        app.context.renderString = renderString
       }
     },
 
@@ -156,7 +156,7 @@ function Jade (options) {
       enumerable: true,
       value: function* (next) {
         this.render = renderer
-        this.render_string = render_string
+        this.renderString = renderString
         yield next
       }
     },

--- a/test/index.js
+++ b/test/index.js
@@ -116,6 +116,42 @@ describe('koa-jade', function () {
       })
     })
 
+    describe('render_string', function () {
+      it('should render Jade template string', function (done) {
+        var app = Koa()
+        new Jade({ app: app })
+
+        app.use(function* (next) {
+          this.state.name = 'Jade'
+          this.body = this.render_string('h1 Hello, #{name}', {}, { fromString: true })
+          yield next
+        })
+
+        request(app).get('/').expect(function (res) {
+          $(res.text).text().should.eql('Hello, Jade')
+        })
+        .expect(200, done)
+      })
+
+      it('should render Jade file', function (done) {
+        var app = Koa()
+        new Jade({ app: app, viewPath: __dirname, basedir: __dirname })
+
+        app.use(function* (next) {
+          this.state.name = 'Jade'
+          this.body = this.render_string('textuals/hello')
+          yield next
+        })
+
+        request(app).get('/').expect(function (res) {
+          var doc = $(res.text)
+          doc.hasClass('content').should.be.true
+          doc.find('h1').text().should.eql('Hello, Jade')
+        })
+        .expect(200, done)
+      })
+    })
+
     describe('options', function () {
       it('should always be an object and only accept object value', function () {
         var jade = new Jade()

--- a/test/index.js
+++ b/test/index.js
@@ -116,14 +116,14 @@ describe('koa-jade', function () {
       })
     })
 
-    describe('render_string', function () {
+    describe('renderString', function () {
       it('should render Jade template string', function (done) {
         var app = Koa()
         new Jade({ app: app })
 
         app.use(function* (next) {
           this.state.name = 'Jade'
-          this.body = this.render_string('h1 Hello, #{name}', {}, { fromString: true })
+          this.body = this.renderString('h1 Hello, #{name}', {}, { fromString: true })
           yield next
         })
 
@@ -139,7 +139,7 @@ describe('koa-jade', function () {
 
         app.use(function* (next) {
           this.state.name = 'Jade'
-          this.body = this.render_string('textuals/hello')
+          this.body = this.renderString('textuals/hello')
           yield next
         })
 


### PR DESCRIPTION
`render_string` return rendered template string, not set to `this.body`
it's useful like this

``` js
app.use(function* () {
  this.body = {
    html: this.render_string('index', locals_for_this_page, true)
  }
})
```
