### PR TITLE
Support the parameterized context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/cheerio": "^0.22.12",
         "@types/fs-extra": "^8.0.0",
         "@types/got": "^9.6.5",
-        "@types/koa": "^2.0.49",
+        "@types/koa": "^2.13.5",
         "@types/koa-router": "^7.0.42",
         "@types/lodash.camelcase": "^4.3.6",
         "@types/lodash.forin": "^4.4.6",
@@ -224,6 +224,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
+      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==",
+      "dev": true
+    },
     "node_modules/@types/cookies": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.2.tgz",
@@ -300,6 +306,12 @@
       "integrity": "sha512-8CBLG8RmxSvoY07FE6M/QpvJ7J5KzeKqF8eWN7Dq6Ks+lBTQae8Roc2G81lUu2Kw5Ju1gymOuvgyUsussbjAaA==",
       "dev": true
     },
+    "node_modules/@types/http-errors": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -313,14 +325,16 @@
       "dev": true
     },
     "node_modules/@types/koa": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.49.tgz",
-      "integrity": "sha512-WQWpCH8O4Dslk8IcXfazff40aM1jXX7BQRbADIj/fKozVPu76P/wQE4sRe2SCWMn8yNkOcare2MkDrnZqLMkPQ==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.5.tgz",
+      "integrity": "sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==",
       "dev": true,
       "dependencies": {
         "@types/accepts": "*",
+        "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
+        "@types/http-errors": "*",
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"
@@ -6302,6 +6316,12 @@
         "@types/node": "*"
       }
     },
+    "@types/content-disposition": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
+      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==",
+      "dev": true
+    },
     "@types/cookies": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.2.tgz",
@@ -6378,6 +6398,12 @@
       "integrity": "sha512-8CBLG8RmxSvoY07FE6M/QpvJ7J5KzeKqF8eWN7Dq6Ks+lBTQae8Roc2G81lUu2Kw5Ju1gymOuvgyUsussbjAaA==",
       "dev": true
     },
+    "@types/http-errors": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -6391,14 +6417,16 @@
       "dev": true
     },
     "@types/koa": {
-      "version": "2.0.49",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.0.49.tgz",
-      "integrity": "sha512-WQWpCH8O4Dslk8IcXfazff40aM1jXX7BQRbADIj/fKozVPu76P/wQE4sRe2SCWMn8yNkOcare2MkDrnZqLMkPQ==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.5.tgz",
+      "integrity": "sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==",
       "dev": true,
       "requires": {
         "@types/accepts": "*",
+        "@types/content-disposition": "*",
         "@types/cookies": "*",
         "@types/http-assert": "*",
+        "@types/http-errors": "*",
         "@types/keygrip": "*",
         "@types/koa-compose": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/cheerio": "^0.22.12",
     "@types/fs-extra": "^8.0.0",
     "@types/got": "^9.6.5",
-    "@types/koa": "^2.0.49",
+    "@types/koa": "^2.13.5",
     "@types/koa-router": "^7.0.42",
     "@types/lodash.camelcase": "^4.3.6",
     "@types/lodash.forin": "^4.4.6",

--- a/source/index.ts
+++ b/source/index.ts
@@ -141,11 +141,11 @@ export class KoaPug {
    * Bind render function to Koa context
    * @param app Koa instance
    */
-  use (app: Koa) {
+  use <StateT = Koa.DefaultState, CustomT = Koa.DefaultContext>(app: Koa<StateT, CustomT>) {
     const self = this
     app.context.render = async function (tpl: string, locals?: any, options?: any) {
       const ctx = this
-      const finalLocals = merge({}, self.helpers, self.defaultLocals, ctx.state, locals)
+      const finalLocals = merge({}, self.helpers, self.defaultLocals, (ctx as any).state, locals)
       ctx.body = await self.render(tpl, finalLocals, options)
       ctx.type = 'text/html'
     }
@@ -164,13 +164,13 @@ declare module 'koa' {
   }
 }
 
-interface PugOptions extends pug.Options {
+interface PugOptions<StateT = Koa.DefaultState, CustomT = Koa.DefaultContext> extends pug.Options {
   [key: string]: any
 
   /**
    * Koa instance
    */
-  app?: Koa
+  app?: Koa<StateT, CustomT>
 
   /**
    * Paths of helpers.


### PR DESCRIPTION
Supported `@types/koa`'s parameterized context.
Without this, a parameterized Koa instance cannot be passed to `pug.use()` due to a type mismatch.

See also:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/31704
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37901